### PR TITLE
Meal Endpoint: Remove food from meal

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A calorie tracker using JavaScript, built on NodeJS with the Express framework.
 [Foods Create](#foods-create)
 [Meals Index](#meals-index)
 [Meals Show](#meals-show)
+[Add Food to Meal](#add-food-to-meal)
+[Remove Food from Meal](#remove-food-from-meal)
 
 ---
 
@@ -355,6 +357,73 @@ HTTP/1.1 201 Created
 {
   "message": "Successfully added <Food name> to <Meal name>"
 }
+```
+
+##### Failed Response - Unable to find requested meal
+
+This error will be returned when the requested ID does not match a Meal in the database.
+
+```http
+HTTP/1.1 404 Not Found
+```
+
+###### Body
+
+```js
+{"error": "No meal found with the provided ID."}
+```
+
+##### Failed Response - Unable to find requested food
+
+This error will be returned when the requested ID does not match a Food in the database.
+
+```http
+HTTP/1.1 404 Not Found
+```
+
+###### Body
+
+```js
+{"error": "No food found with the provided ID."}
+```
+
+##### Failed Response - Other
+
+There are no other anticipated failure states. A failure for any other reason is unexpected and will follow the below format.
+
+```http
+HTTP/1.1 500 Internal Server Error
+```
+
+###### Body
+
+```js
+{"error": "Internal Server Error"}
+```
+
+---
+
+#### Remove Food from Meal
+
+Given the ID of a meal and the ID of a food, remove the food from the meal.
+
+##### Requirements
+
+- Provided meal ID must match a meal that exists in the database.
+- Provided food ID must match a food that exists in the database.
+
+##### Request
+
+```http
+DELETE /api/v1/meals/:meal_id/foods/:id
+```
+
+##### Successful Response
+
+A message indicating that the food was added to the meal successfully.
+
+```http
+HTTP/1.1 204 No Content
 ```
 
 ##### Failed Response - Unable to find requested meal

--- a/config/jest.environment.js
+++ b/config/jest.environment.js
@@ -26,4 +26,5 @@ global.app = require('../app')
 global.request = require('supertest')(app)
 global.get = request.get
 global.post = request.post
+global.del = request.del
 global.DB = SequelizeExecutor

--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -68,4 +68,29 @@ meals.post('/:mealId/foods/:foodId', (req, res, next) => {
   })
 })
 
+meals.delete('/:mealId/foods/:foodId', (req, res, next) => {
+  res.setHeader("Content-Type", "application/json")
+  Meal.findByPk(req.params.mealId).then(meal => {
+    if(meal){
+      Food.findByPk(req.params.foodId).then(food => {
+        if(food){
+          meal.removeFood(food).then(result => {
+            res.status(204).send()
+          }).catch(error => {
+            res.status(500).send({error: "Internal Server Error"})
+          })
+        } else {
+          res.status(404).send({error: "No food found with the provided ID."})
+        }
+      }).catch(error => {
+        res.status(500).send({error: "Internal Server Error"})
+      })
+    } else {
+      res.status(404).send({error: "No meal found with the provided ID."})
+    }
+  }).catch(error => {
+    res.status(500).send({error: "Internal Server Error"})
+  })
+})
+
 module.exports = meals

--- a/spec/api/v1/meals/add_food.spec.js
+++ b/spec/api/v1/meals/add_food.spec.js
@@ -1,7 +1,7 @@
 const Meal = require('../../../../models').Meal
 const Food = require('../../../../models').Food
 
-describe('Meals index', () => {
+describe('Meals add food endpoint', () => {
   beforeAll(() => {
     DB.create()
   });
@@ -29,6 +29,18 @@ describe('Meals index', () => {
       expect(response.statusCode).toBe(201)
 
       expect(response.body.message).toBe("Successfully added Banana to Breakfast")
+
+      let affectedMeal = await Meal.findByPk(1, {
+        include: [{
+          model: Food,
+          attributes: ["id", "name", "calories"],
+          through: {
+            attributes: []
+          }
+        }]
+      })
+      expect(affectedMeal.Food).toHaveLength(2)
+      expect(affectedMeal.Food[1].name).toBe("Banana")
     })
   })
 

--- a/spec/api/v1/meals/remove_food.spec.js
+++ b/spec/api/v1/meals/remove_food.spec.js
@@ -1,0 +1,78 @@
+const Meal = require('../../../../models').Meal
+const Food = require('../../../../models').Food
+
+describe('Meals remove food endpoint', () => {
+  beforeAll(() => {
+    DB.create()
+  });
+
+  afterAll(() => {
+    DB.drop()
+  })
+
+  describe('Successful request', () => {
+    beforeEach(() => {
+      DB.migrate()
+    })
+
+    afterEach(() => {
+      DB.wipe()
+    })
+
+    it('removes a food from a meal', async () => {
+      let meal1 = await Meal.create({name: "Breakfast", Food: [
+        {name: "Cereal", calories: 240},
+        {name: "Banana", calories: 150}
+      ]}, {include: [Food]})
+
+      let response = await del("/api/v1/meals/1/foods/2")
+      expect(response.statusCode).toBe(204)
+
+      let affectedMeal = await Meal.findByPk(1, {
+        include: [{
+          model: Food,
+          attributes: ["id", "name", "calories"],
+          through: {
+            attributes: []
+          }
+        }]
+      })
+      expect(affectedMeal.Food).toHaveLength(1)
+      expect(affectedMeal.Food[0].name).not.toBe("Banana")
+    })
+  })
+
+  describe('Failed requests', () => {
+    it('returns a 500 if it is unable to complete the request', async () => {
+      let response = await del("/api/v1/meals/1/foods/1")
+      expect(response.statusCode).toBe(500)
+      expect(response.body.error).toBe("Internal Server Error")
+    })
+
+    it('returns a 404 if it is unable to find the requested meal', async () => {
+      DB.migrate()
+
+      let meal1 = await Meal.create({name: "Breakfast", Food: [
+        {name: "Cereal", calories: 240},
+        {name: "Banana", calories: 150}
+      ]}, {include: [Food]})
+
+      let response = await del("/api/v1/meals/2/foods/1")
+      expect(response.statusCode).toBe(404)
+      expect(response.body.error).toBe("No meal found with the provided ID.")
+    })
+
+    it('returns a 404 if it is unable to find the requested food', async () => {
+      DB.migrate()
+
+      let meal1 = await Meal.create({name: "Breakfast", Food: [
+        {name: "Cereal", calories: 240},
+        {name: "Banana", calories: 150}
+      ]}, {include: [Food]})
+
+      let response = await del("/api/v1/meals/1/foods/3")
+      expect(response.statusCode).toBe(404)
+      expect(response.body.error).toBe("No food found with the provided ID.")
+    })
+  })
+})


### PR DESCRIPTION
Closes #10 
```
As an API client
  when I send a DELETE request to /api/v1/meals/:meal_id/foods/:id
  where :meal_id is a valid ID for a meal record in the database
  where :id is a valid ID for a food record in the database
I receive an empty response with the appropriate HTTP status
```
- Creates an endpoint at DELETE /api/v1/meals/:meal_id/foods/:food_id which removes the provided food from the provided meal.
- Requests with invalid meal or food IDs will receive a 404 message.

#### Required Steps
- [x] Wrote Tests
- [x] Implemented
- [x] Self-Reviewed

#### Neccesary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally

#### Type of change
- [x] New feature
- [ ] Bug Fix

#### Check the applicable boxes
- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

#### Testing Changes
- [x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

#### Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
