### PR TITLE
Meal Endpoints: Delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This project is a Mod 4 assignment from the Turing School of Software and Design
 |[Show](#foods-show)|[Show](#meals-show)|
 |[Create](#foods-create)|[Create](#meals-create)|
 |[Update](#foods-update)||
+||[Delete](#meals-delete)|
 ||[Add Food](#add-food-to-meal)|
 ||[Remove Food](#remove-food-from-meal)|
 
@@ -547,7 +548,7 @@ DELETE /api/v1/meals/:meal_id/foods/:id
 
 ##### Successful Response
 
-A message indicating that the food was added to the meal successfully.
+A message indicating that the food was removed from the meal successfully.
 
 ```http
 HTTP/1.1 204 No Content
@@ -579,6 +580,58 @@ HTTP/1.1 404 Not Found
 
 ```js
 {"error": "No food found with the provided ID."}
+```
+
+##### Failed Response - Other
+
+There are no other anticipated failure states. A failure for any other reason is unexpected and will follow the below format.
+
+```http
+HTTP/1.1 500 Internal Server Error
+```
+
+###### Body
+
+```js
+{"error": "Internal Server Error"}
+```
+
+---
+
+#### Delete Meal
+
+Given the ID of a meal, delete the meal from the database.
+
+##### Requirements
+
+- Provided meal ID must match a meal that exists in the database.
+
+##### Request
+
+```http
+DELETE /api/v1/meals/:meal_id
+```
+
+##### Successful Response
+
+A message indicating that the meal was deleted successfully.
+
+```http
+HTTP/1.1 204 No Content
+```
+
+##### Failed Response - Unable to find requested meal
+
+This error will be returned when the requested ID does not match a Meal in the database.
+
+```http
+HTTP/1.1 404 Not Found
+```
+
+###### Body
+
+```js
+{"error": "No meal found with the provided ID."}
 ```
 
 ##### Failed Response - Other

--- a/migrations/20190702200442-create-meal-food.js
+++ b/migrations/20190702200442-create-meal-food.js
@@ -13,14 +13,16 @@ module.exports = {
         references: {
           model: 'Meals',
           key: 'id'
-        }
+        },
+        onDelete: 'cascade'
       },
       FoodId: {
         type: Sequelize.INTEGER,
         references: {
           model: 'Food',
           key: 'id'
-        }
+        },
+        onDelete: 'cascade'
       },
       createdAt: {
         allowNull: false,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "start": "node bin/www",
     "test": "jest --runInBand --config ./config/jest.config.js",
     "travis-test": "jest --runInBand --config ./config/jest.config.js --detectOpenHandles --forceExit",
-    "debug-test": "NODE_ENV=debug-test node --inspect-brk node_modules/.bin/jest --runInBand"
+    "debug-test": "NODE_ENV=debug-test node --inspect-brk node_modules/.bin/jest --runInBand --config ./config/jest.config.js"
   },
   "repository": {
     "type": "git",

--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -106,11 +106,13 @@ meals.post('/', (req, res, next) => {
 /* Delete Meal */
 meals.delete('/:id', (req, res, next) => {
   res.setHeader("Content-Type", "application/json")
-  Meal.findByPk(req.params.id).then(meal => {
-    if(meal){
-      return meal.destroy().then(result => {
-        res.status(204).send()
-      })
+  Meal.destroy({
+    where: {
+      id: req.params.id
+    }
+  }).then(meal => {
+    if(meal !== 0){
+      res.status(204).send()
     } else {
       res.status(404).send({error: "No meal found with the provided ID."})
     }

--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -3,6 +3,7 @@ var models = require('../../../models');
 const Meal = models.Meal
 const Food = models.Food
 
+/* Meals Index */
 meals.get('/', (req, res, next) => {
   res.setHeader("Content-Type", "application/json")
   Meal.findAll({
@@ -21,6 +22,7 @@ meals.get('/', (req, res, next) => {
   })
 })
 
+/* Meal Show */
 meals.get('/:id', (req, res, next) => {
   res.setHeader("Content-Type", "application/json")
   Meal.findByPk(req.params.id, {
@@ -43,6 +45,7 @@ meals.get('/:id', (req, res, next) => {
   })
 })
 
+/* Add Food to Meal */
 meals.post('/:mealId/foods/:foodId', (req, res, next) => {
   res.setHeader("Content-Type", "application/json")
   Meal.findByPk(req.params.mealId).then(meal => {
@@ -64,6 +67,7 @@ meals.post('/:mealId/foods/:foodId', (req, res, next) => {
   })
 })
 
+/* Remove Food from Meal */
 meals.delete('/:mealId/foods/:foodId', (req, res, next) => {
   res.setHeader("Content-Type", "application/json")
   Meal.findByPk(req.params.mealId).then(meal => {
@@ -85,6 +89,7 @@ meals.delete('/:mealId/foods/:foodId', (req, res, next) => {
   })
 })
 
+/* Create Meal */
 meals.post('/', (req, res, next) => {
   res.setHeader("Content-Type", "application/json")
   if(isMeal(req.body)){
@@ -96,6 +101,22 @@ meals.post('/', (req, res, next) => {
   } else {
     res.status(400).send({error: "Invalid request. Please confirm request body matches API specification."})
   }
+})
+
+/* Delete Meal */
+meals.delete('/:id', (req, res, next) => {
+  res.setHeader("Content-Type", "application/json")
+  Meal.findByPk(req.params.id).then(meal => {
+    if(meal){
+      return meal.destroy().then(result => {
+        res.status(204).send()
+      })
+    } else {
+      res.status(404).send({error: "No meal found with the provided ID."})
+    }
+  }).catch(error => {
+    res.status(500).send({error: "Internal Server Error"})
+  })
 })
 
 module.exports = meals

--- a/spec/api/v1/meals/delete.spec.js
+++ b/spec/api/v1/meals/delete.spec.js
@@ -1,0 +1,56 @@
+const Meal = require('../../../../models').Meal
+const Food = require('../../../../models').Food
+
+describe('Meals delete', () => {
+  beforeAll(() => {
+    DB.create()
+  });
+
+  afterAll(() => {
+    DB.drop()
+  })
+
+  describe('Successful request', () => {
+    beforeEach(() => {
+      DB.migrate()
+    })
+
+    afterEach(() => {
+      DB.wipe()
+    })
+
+    it('deletes an existing meal', async () => {
+      let meal1 = await Meal.create({name: "Breakfast", Food: [
+        {name: "Cereal", calories: 240}
+      ]}, {include: [Food]})
+      let response = await del("/api/v1/meals/1")
+
+      expect(response.statusCode).toBe(204)
+
+      let remainingFood = await Food.findByPk(1)
+      expect(remainingFood.name).toBe("Cereal")
+    })
+  })
+
+  describe('Failed requests', () => {
+    it('returns a 500 if it is unable to complete the request', async () => {
+      let response = await del("/api/v1/meals/1")
+
+      expect(response.statusCode).toBe(500)
+      expect(response.body.error).toBe("Internal Server Error")
+    })
+
+    it('returns a 404 if it is unable to find the requested meal', async () => {
+      DB.migrate()
+
+      let meal1 = await Meal.create({name: "Breakfast", Food: [
+        {name: "Cereal", calories: 240},
+        {name: "Banana", calories: 150}
+      ]}, {include: [Food]})
+
+      let response = await del("/api/v1/meals/2")
+      expect(response.statusCode).toBe(404)
+      expect(response.body.error).toBe("No meal found with the provided ID.")
+    })
+  })
+})


### PR DESCRIPTION
Closes #27 
```
As an API client
  when I send a DELETE request to /api/v1/meals/:id
  where :id is a valid ID for a meal record
I receive an empty response with the appropriate HTTP status
```
- Adds an endpoint at `DELETE /api/v1/meals/:id` to delete an existing Meal.

#### Required Steps
- [x] Wrote Tests
- [x] Implemented
- [x] Self-Reviewed

#### Neccesary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally

#### Type of change
- [x] New feature
- [ ] Bug Fix

#### Check the applicable boxes
- [x] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

#### Testing Changes
- [x] No Tests have been changed
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)
__Notes:__

#### Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
